### PR TITLE
[Agent] Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:tailwindcss/recommended",
+    "prettier"
+  ],
+  "plugins": ["tailwindcss", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "tailwindcss/no-custom-classname": "off"
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm run type-check
+npm run test:coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,174 @@
-# queue-tube-web
+# QueueTube Web
+
+Production-ready Next.js 15 app with gluestack-ui v3, Vitest, ESLint, Prettier, and Git quality gates.
+
+---
+
+## Prerequisites
+
+- Node.js ≥ 20
+- pnpm ≥ 9
+
+---
+
+## Setup (in order)
+
+### 1. Clone and install dependencies
+
+```bash
+git clone https://github.com/spreadcode-dev/queue-tube-web.git
+cd queue-tube-web
+pnpm install
+```
+
+### 2. Bootstrap Next.js (new repo only)
+
+```bash
+npx create-next-app@latest queue-tube-web \
+  --typescript \
+  --tailwind \
+  --eslint \
+  --app \
+  --src-dir \
+  --import-alias "@/*"
+```
+
+### 3. Initialise gluestack-ui v3
+
+```bash
+npx gluestack-ui init
+```
+
+After init, apply QueueTube design tokens in `src/app/gluestack-ui-provider/config.ts`:
+
+```ts
+"--color-primary-500": "#E94560",
+"--color-primary-400": "#f05a72",
+"--color-primary-600": "#c73550",
+// ... (see config.ts for full token list)
+```
+
+### 4. Install Vitest + React Testing Library
+
+```bash
+pnpm add -D vitest @vitejs/plugin-react jsdom \
+  @testing-library/react @testing-library/dom \
+  @testing-library/user-event \
+  vite-tsconfig-paths \
+  @vitest/coverage-v8
+```
+
+### 5. Install Prettier + ESLint plugins
+
+```bash
+pnpm add -D prettier \
+  prettier-plugin-tailwindcss \
+  eslint-config-prettier \
+  eslint-plugin-prettier \
+  eslint-plugin-tailwindcss
+```
+
+### 6. Install Git hook toolchain
+
+```bash
+pnpm add -D husky lint-staged \
+  @commitlint/cli \
+  @commitlint/config-conventional
+npx husky init
+```
+
+### 7. Start the dev server
+
+```bash
+pnpm dev
+```
+
+---
+
+## Scripts
+
+| Script | Description |
+|---|---|
+| `pnpm dev` | Start dev server with Turbopack |
+| `pnpm build` | Production build |
+| `pnpm lint` | Run ESLint |
+| `pnpm lint:fix` | Run ESLint with auto-fix |
+| `pnpm format` | Format all files with Prettier |
+| `pnpm format:check` | Check formatting without writing |
+| `pnpm type-check` | TypeScript type check (no emit) |
+| `pnpm test` | Run Vitest in watch mode |
+| `pnpm test:run` | Run Vitest once |
+| `pnpm test:coverage` | Run Vitest with coverage report |
+
+---
+
+## Git Hooks
+
+All hooks are managed by **Husky v9** and run automatically.
+
+### `pre-commit`
+
+**What it does:** Runs `lint-staged` on staged `.ts/.tsx` files only.
+
+**What it validates:**
+- ESLint — catches code errors and enforces style rules
+- Prettier — enforces consistent formatting and Tailwind class ordering
+
+**Effect:** Staged files that fail lint or formatting checks will block the commit.
+
+### `commit-msg`
+
+**What it does:** Runs `commitlint` to validate the commit message.
+
+**What it validates:** Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+**Examples:**
+- ✅ `feat(queue): add video reordering`
+- ✅ `fix(auth): resolve null state on logout`
+- ❌ `fixed stuff` — blocked
+- ❌ `WIP` — blocked
+
+**Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`, `revert`
+
+### `pre-push`
+
+**What it does:** Runs full type check and full test suite with coverage enforcement before pushing to remote.
+
+**What it validates:**
+1. `tsc --noEmit` — catches TypeScript type errors that may have been bypassed locally
+2. `vitest run --coverage` — runs all tests and enforces ≥ 80% coverage on lines, branches, functions, and statements
+
+**Effect:** A push is blocked if type errors exist or if coverage falls below 80%.
+
+### Bypassing hooks (emergency use only)
+
+All hooks can be bypassed with the `--no-verify` flag:
+
+```bash
+git commit --no-verify -m "chore: emergency fix"
+git push --no-verify
+```
+
+> ⚠️ Use `--no-verify` only in genuine emergencies. Bypassed commits should be followed immediately by a fix commit that restores passing checks.
+
+---
+
+## Coverage
+
+Coverage reports are generated in the `/coverage` directory after running `pnpm test:coverage`.
+
+Open `coverage/index.html` in a browser to view the full HTML report.
+
+Thresholds (enforced at push time):
+- Lines: ≥ 80%
+- Branches: ≥ 80%
+- Functions: ≥ 80%
+- Statements: ≥ 80%
+
+---
+
+## Design Tokens
+
+QueueTube design tokens are defined in `src/app/gluestack-ui-provider/config.ts`. Always use CSS variable aliases in components (e.g. `bg-primary-500`, `bg-background-0`) — never raw hex values.
+
+See [DESIGN_PIPELINE.md](https://github.com/spreadcode-dev/queue-tube-mcps/blob/main/docs/DESIGN_PIPELINE.md) for the full token specification.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,12 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "perf", "revert"],
+    ],
+    "subject-max-length": [2, "always", 72],
+    "subject-case": [2, "always", "lower-case"],
+  },
+};

--- a/src/app/gluestack-ui-provider/config.ts
+++ b/src/app/gluestack-ui-provider/config.ts
@@ -1,0 +1,26 @@
+export const config = {
+  // ── QueueTube colour overrides ───────────────────────────────────────────
+  "--color-primary-500": "#E94560", // CTAs, FAB, active states, badges
+  "--color-primary-400": "#f05a72", // hover
+  "--color-primary-600": "#c73550", // pressed
+
+  "--color-background-dark": "#181719", // page background, nav
+  "--color-background-0": "#121212", // cards, modals, bottom sheets
+  "--color-background-50": "#272625", // elevated surfaces, sidebars
+
+  "--color-typography-900": "#f5f5f5", // body text
+  "--color-typography-400": "#8c8c8c", // secondary text, labels
+  "--color-typography-600": "#d4d4d4", // placeholder, disabled
+
+  "--color-outline-300": "#737474", // card borders, dividers
+  "--color-outline-100": "#414141", // subtle borders
+
+  "--color-error-400": "#e63535", // destructive actions
+  "--color-success-500": "#489766", // success states
+  "--color-info-400": "#0da6f2", // info badges / links
+
+  // ── Radius ───────────────────────────────────────────────────────────────
+  "--radius-xl": "12px", // cards, panels, modals
+  "--radius-lg": "8px", // buttons, inputs
+  "--radius-full": "9999px", // avatars, FAB
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "QueueTube",
+  description: "Manage your YouTube watch queue",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <GluestackUIProvider mode="dark">{children}</GluestackUIProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/components/QueueCard.test.tsx
+++ b/src/components/QueueCard.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { QueueCard } from "./QueueCard";
+
+// Minimal mocks for gluestack-ui primitives so tests run in jsdom without RN
+vi.mock("@/components/ui", () => ({
+  Box: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Pressable: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => <button onClick={onPress}>{children}</button>,
+  Text: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+  HStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  VStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+describe("QueueCard", () => {
+  it("renders the queue name", () => {
+    render(<QueueCard name="My Queue" videoCount={5} />);
+    expect(screen.getByText("My Queue")).toBeTruthy();
+  });
+
+  it("renders the video count", () => {
+    render(<QueueCard name="My Queue" videoCount={5} />);
+    expect(screen.getByText("5 videos")).toBeTruthy();
+  });
+
+  it("calls onPress when the card is pressed", async () => {
+    const user = userEvent.setup();
+    const onPress = vi.fn();
+    render(<QueueCard name="My Queue" videoCount={3} onPress={onPress} />);
+    await user.click(screen.getByRole("button"));
+    expect(onPress).toHaveBeenCalledOnce();
+  });
+
+  it("applies active border class when isActive is true", () => {
+    const { container } = render(<QueueCard name="Active Queue" videoCount={2} isActive />);
+    expect(container.innerHTML).toContain("border-l-primary-500");
+  });
+
+  it("does not apply active border class when isActive is false", () => {
+    const { container } = render(<QueueCard name="Inactive Queue" videoCount={1} isActive={false} />);
+    expect(container.innerHTML).not.toContain("border-l-primary-500");
+  });
+
+  it("renders with default isActive=false when prop is omitted", () => {
+    const { container } = render(<QueueCard name="Default Queue" videoCount={0} />);
+    expect(container.innerHTML).not.toContain("border-l-primary-500");
+  });
+});

--- a/src/components/QueueCard.tsx
+++ b/src/components/QueueCard.tsx
@@ -1,0 +1,29 @@
+import { Box, Pressable, Text, HStack, VStack } from "@/components/ui";
+
+interface QueueCardProps {
+  name: string;
+  videoCount: number;
+  isActive?: boolean;
+  onPress?: () => void;
+}
+
+export function QueueCard({ name, videoCount, isActive = false, onPress }: QueueCardProps) {
+  return (
+    <Pressable onPress={onPress}>
+      <Box
+        className={[
+          "rounded-xl px-4 py-3",
+          "bg-background-0 border border-outline-300",
+          isActive ? "border-l-4 border-l-primary-500" : "",
+        ].join(" ")}
+      >
+        <HStack space="sm" className="items-center">
+          <VStack className="flex-1">
+            <Text className="text-typography-900 font-bold text-md">{name}</Text>
+            <Text className="text-typography-400 text-sm">{videoCount} videos</Text>
+          </VStack>
+        </HStack>
+      </Box>
+    </Pressable>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      exclude: [
+        "node_modules/",
+        "src/test/",
+        "src/app/gluestack-ui-provider/",
+        "**/*.config.*",
+        "**/*.d.ts",
+      ],
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Source story

Closes #1 — Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

---

## Summary

(see issue body)

---

## Files changed

- `vitest.config.mts`
- `src/test/setup.ts`
- `.eslintrc.json`
- `.prettierrc`
- `commitlint.config.ts`
- `.husky/pre-commit`
- `.husky/commit-msg`
- `.husky/pre-push`
- `src/app/gluestack-ui-provider/config.ts`
- `src/app/layout.tsx`
- `src/components/QueueCard.tsx`
- `src/components/QueueCard.test.tsx`
- `README.md`

---

## Testing checklist

- [ ] `create-next-app` runs successfully with TypeScript, App Router, Tailwind, `src/` directory, and `@/*` path alias
- [ ] gluestack-ui v3 CLI init completes and the provider is correctly wired in the root layout
- [ ] QueueTube design tokens are applied in `gluestack-ui-provider/config.ts` (primary red, background scale, typography scale, radius)
- [ ] `pnpm dev` starts the dev server cleanly with no console errors
- [ ] Vitest is configured with `jsdom` environment, React plugin, and tsconfig path resolution
- [ ] `@testing-library/react` and `@testing-library/user-event` are installed and working
- [ ] A sample test for a synchronous component passes (`pnpm test:run`)
- [ ] `pnpm test:coverage` generates an HTML coverage report in `/coverage`
- [ ] Coverage thresholds (lines, branches, functions, statements ≥ 80%) are defined in `vitest.config.mts`
- [ ] `pnpm lint` runs ESLint with `next/core-web-vitals`, `tailwindcss/recommended`, and `prettier` extensions
- [ ] `pnpm format:check` runs with zero errors on a freshly bootstrapped project
- [ ] `eslint-plugin-tailwindcss` detects invalid Tailwind class names as lint errors
- [ ] `prettier-plugin-tailwindcss` reorders Tailwind classes automatically on format
- [ ] `pre-commit`: lint-staged runs ESLint + Prettier on staged `.ts/.tsx` files before commit — invalid commits are blocked
- [ ] `commit-msg`: commitlint rejects messages that don't follow Conventional Commits (e.g. `"fixed stuff"` fails; `"fix(queue): resolve null state"` passes)
- [ ] `pre-push`: full `tsc --noEmit` type check runs before push — type errors block the push
- [ ] `pre-push`: `vitest run --coverage` runs before push — coverage below 80% blocks the push
- [ ] All hooks can be bypassed with `--no-verify` for emergency use (documented in README)
- [ ] `README.md` documents all setup commands in order, including gluestack-ui init and token override step
- [ ] `README.md` includes a section on Git hooks: what each hook does, what it validates, and how to bypass in emergencies
- [ ] `docs/code-context.md` is created with the initial project baseline (directory tree, key config files, reference component) — used by the Code Sync agent
- [ ] Should `pre-push` also run `next build` to catch build-time errors? (Slower but more complete)
- [ ] Is pnpm the agreed package manager, or is npm/yarn preferred for this project?
- [ ] Should Playwright be set up in this issue as the E2E layer for async RSC testing, or tracked as a separate issue?
- [ ] Bootstrap Next.js project with all CLI flags
- [ ] Run `npx gluestack-ui init` and apply QueueTube token overrides
- [ ] Configure Vitest with coverage thresholds
- [ ] Configure ESLint + Prettier with Tailwind plugins
- [ ] Configure Husky with `pre-commit`, `commit-msg`, and `pre-push` hooks
- [ ] Configure lint-staged and commitlint
- [ ] Write a passing sample test to verify the test setup end-to-end
- [ ] Verify all three hooks fire correctly on a test commit and push
- [ ] Create `docs/code-context.md` with initial baseline content for the Code Sync agent
- [ ] Update `README.md` with full setup instructions and hook documentation

---

## Notes for reviewer

## Assumptions & Decisions

1. **GluestackUIProvider import path**: The layout.tsx imports from `@/components/ui/gluestack-ui-provider` — this is the standard path after `npx gluestack-ui init` copies the provider component. If the actual path differs post-init, it may need adjustment.

2. **QueueCard mock strategy**: The test file mocks `@/components/ui` entirely with lightweight HTML equivalents so tests run in jsdom without React Native peer dependencies. This is the standard pattern for gluestack-ui v3 copy-paste components in a Vitest/jsdom environment.

3. **globals.css**: The root layout imports `./globals.css` which is expected to be scaffolded by `create-next-app`. Not generated here as it falls outside the story's deliverables.

4. **Sample test**: The acceptance criteria requires "a sample test for a synchronous component passes". The `QueueCard.test.tsx` satisfies this — it's the reference component from the baseline and is synchronous (no async RSC).

5. **Husky hook file format**: Husky v9 hooks are plain shell scripts without `.sh` extension in `.husky/`. The `#!/usr/bin/env sh` shebang is included for portability.

6. **pnpm vs npm in pre-push**: The story uses both `pnpm` and `npm` in different sections. The `.husky/pre-push` hook uses `npm run` to match the story's Git Hooks section verbatim. Teams can swap to `pnpm run` if preferred.

7. **`docs/code-context.md`**: The baseline context file already exists at this path per the baseline snapshot. It is not regenerated here to avoid overwriting it — the story states it should be "created with initial baseline content" which the repo baseline already satisfies.

8. **AC not fully addressed**: The ACs around `pnpm dev` starting cleanly, `next build` succeeding, and verifying hooks fire on a test commit are runtime/CI verification steps that cannot be satisfied by generated files alone.

---
*Generated by the QueueTube Code Agent · Powered by Claude*