### PR TITLE
[Agent] Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:tailwindcss/recommended",
+    "prettier"
+  ],
+  "plugins": ["tailwindcss", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "tailwindcss/no-custom-classname": "off"
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm run type-check
+npm run test:coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,190 @@
-# queue-tube-web
+# QueueTube Web
+
+The QueueTube web application — built with Next.js 15 (App Router), gluestack-ui v3, and NativeWind/Tailwind CSS.
+
+---
+
+## Setup Instructions
+
+### Prerequisites
+
+- Node.js ≥ 20
+- pnpm (recommended) or npm
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/spreadcode-dev/queue-tube-web.git
+cd queue-tube-web
+```
+
+### 2. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 3. Bootstrap the project (first time only)
+
+If setting up from scratch:
+
+```bash
+# Create Next.js project
+npx create-next-app@latest queue-tube-web \
+  --typescript \
+  --tailwind \
+  --eslint \
+  --app \
+  --src-dir \
+  --import-alias "@/*"
+
+# Initialise gluestack-ui v3
+npx gluestack-ui init
+```
+
+After running `gluestack-ui init`, apply the QueueTube token overrides in
+`src/app/gluestack-ui-provider/config.ts` — see that file for the full token set
+(primary accent red `#E94560`, background scale, typography scale, border radius).
+
+### 4. Install additional dev tooling
+
+```bash
+pnpm add -D vitest @vitejs/plugin-react jsdom \
+  @testing-library/react @testing-library/dom \
+  @testing-library/user-event \
+  vite-tsconfig-paths \
+  @vitest/coverage-v8
+
+pnpm add -D prettier \
+  prettier-plugin-tailwindcss \
+  eslint-config-prettier \
+  eslint-plugin-prettier \
+  eslint-plugin-tailwindcss
+
+pnpm add -D husky lint-staged \
+  @commitlint/cli \
+  @commitlint/config-conventional
+
+npx husky init
+```
+
+### 5. Start the development server
+
+```bash
+pnpm dev
+```
+
+Opens at [http://localhost:3000](http://localhost:3000).
+
+---
+
+## Available Scripts
+
+| Script | Description |
+|---|---|
+| `pnpm dev` | Start dev server with Turbopack |
+| `pnpm build` | Production build |
+| `pnpm lint` | Run ESLint |
+| `pnpm lint:fix` | Run ESLint with auto-fix |
+| `pnpm format` | Format all files with Prettier |
+| `pnpm format:check` | Check formatting without writing |
+| `pnpm type-check` | TypeScript type check (no emit) |
+| `pnpm test` | Run Vitest in watch mode |
+| `pnpm test:run` | Run Vitest once |
+| `pnpm test:coverage` | Run Vitest with coverage report |
+
+---
+
+## Git Hooks
+
+This project uses [Husky v9](https://typicode.github.io/husky/) to enforce quality gates locally.
+Three hooks are configured:
+
+### `pre-commit`
+
+**What it does:** Runs [lint-staged](https://github.com/okonet/lint-staged) on staged files only.
+
+**What it validates:**
+- `.ts` / `.tsx` files: ESLint (with auto-fix) + Prettier (with auto-format)
+- `.json` / `.css` / `.md` files: Prettier (with auto-format)
+
+**Effect:** Invalid or unformatted code in staged files is either auto-fixed or blocks the commit.
+
+---
+
+### `commit-msg`
+
+**What it does:** Runs [commitlint](https://commitlint.js.org/) to validate the commit message.
+
+**What it validates:** Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <subject in lower-case, ≤ 72 chars>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`, `revert`
+
+**Examples:**
+- ✅ `feat(queue): add drag-to-reorder support`
+- ✅ `fix(player): resolve null state on load`
+- ❌ `fixed stuff` — rejected
+- ❌ `WIP` — rejected
+
+---
+
+### `pre-push`
+
+**What it does:** Runs a full type check and full test suite with coverage enforcement before any push.
+
+**What it validates:**
+1. `tsc --noEmit` — TypeScript must compile with no errors
+2. `vitest run --coverage` — all tests must pass **and** coverage must meet the ≥ 80% threshold
+   (lines, branches, functions, statements) configured in `vitest.config.mts`
+
+**Effect:** A push is blocked if there are type errors or if test coverage falls below 80%.
+
+---
+
+### Bypassing hooks in emergencies
+
+All hooks can be bypassed using the `--no-verify` flag:
+
+```bash
+# Skip pre-commit and commit-msg hooks
+git commit --no-verify -m "chore: emergency hotfix"
+
+# Skip pre-push hook
+git push --no-verify
+```
+
+> ⚠️ Use `--no-verify` only in genuine emergencies. Bypassed commits must be followed up
+> with a clean commit that passes all checks.
+
+---
+
+## Design Tokens
+
+QueueTube uses a custom token set applied via `src/app/gluestack-ui-provider/config.ts`.
+Always reference tokens by their Tailwind alias (e.g. `bg-primary-500`, `text-typography-900`) —
+never use raw hex values in component classes.
+
+Key tokens:
+
+| Token | Value | Usage |
+|---|---|---|
+| `primary-500` | `#E94560` | CTAs, FAB, active states, badges |
+| `background-dark` | `#181719` | Page background, nav |
+| `background-0` | `#121212` | Cards, modals |
+| `background-50` | `#272625` | Elevated surfaces, sidebars |
+| `typography-900` | `#f5f5f5` | Body text |
+| `typography-400` | `#8c8c8c` | Secondary text, labels |
+| `outline-300` | `#737474` | Card borders, dividers |
+
+---
+
+## Testing Notes
+
+- Vitest does **not** support async React Server Components. Unit-test synchronous Client Components
+  and utility functions.
+- Use Playwright (future issue) for E2E and async RSC flows.
+- Coverage report is generated in `/coverage` (HTML at `/coverage/index.html`).

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,12 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "perf", "revert"],
+    ],
+    "subject-max-length": [2, "always", 72],
+    "subject-case": [2, "always", "lower-case"],
+  },
+};

--- a/docs/code-context.md
+++ b/docs/code-context.md
@@ -72,12 +72,20 @@ queue-tube-web/
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
+    "start": "next start",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
+    "*.{json,css,md}": ["prettier --write"]
   }
 }
 ```

--- a/src/app/gluestack-ui-provider/config.ts
+++ b/src/app/gluestack-ui-provider/config.ts
@@ -1,0 +1,26 @@
+export const config = {
+  // ── QueueTube colour overrides ───────────────────────────────────────────
+  "--color-primary-500": "#E94560", // CTAs, FAB, active states, badges
+  "--color-primary-400": "#f05a72", // hover
+  "--color-primary-600": "#c73550", // pressed
+
+  "--color-background-dark": "#181719", // page background, nav
+  "--color-background-0": "#121212", // cards, modals, bottom sheets
+  "--color-background-50": "#272625", // elevated surfaces, sidebars
+
+  "--color-typography-900": "#f5f5f5", // body text
+  "--color-typography-400": "#8c8c8c", // secondary text, labels
+  "--color-typography-600": "#d4d4d4", // placeholder, disabled
+
+  "--color-outline-300": "#737474", // card borders, dividers
+  "--color-outline-100": "#414141", // subtle borders
+
+  "--color-error-400": "#e63535", // destructive actions
+  "--color-success-500": "#489766", // success states
+  "--color-info-400": "#0da6f2", // info badges / links
+
+  // ── Radius ───────────────────────────────────────────────────────────────
+  "--radius-xl": "12px", // cards, panels, modals
+  "--radius-lg": "8px", // buttons, inputs
+  "--radius-full": "9999px", // avatars, FAB
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "QueueTube",
+  description: "Manage your video queues",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="bg-background-dark text-typography-900">
+        <GluestackUIProvider mode="dark">{children}</GluestackUIProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/components/QueueCard.test.tsx
+++ b/src/components/QueueCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueueCard } from "./QueueCard";
+
+// Minimal mocks for gluestack-ui primitives used inside QueueCard
+vi.mock("@/components/ui", () => ({
+  Box: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Pressable: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => <button onClick={onPress}>{children}</button>,
+  Text: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+  HStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  VStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+describe("QueueCard", () => {
+  it("renders the queue name", () => {
+    render(<QueueCard name="My Watch Later" videoCount={12} />);
+    expect(screen.getByText("My Watch Later")).toBeInTheDocument();
+  });
+
+  it("renders the video count", () => {
+    render(<QueueCard name="Tech Talks" videoCount={7} />);
+    expect(screen.getByText("7 videos")).toBeInTheDocument();
+  });
+
+  it("applies active styles when isActive is true", () => {
+    const { container } = render(<QueueCard name="Active Queue" videoCount={3} isActive />);
+    const box = container.querySelector(".border-l-primary-500");
+    expect(box).not.toBeNull();
+  });
+
+  it("does not apply active left-border class when isActive is false", () => {
+    const { container } = render(<QueueCard name="Inactive Queue" videoCount={1} isActive={false} />);
+    const box = container.querySelector(".border-l-primary-500");
+    expect(box).toBeNull();
+  });
+
+  it("calls onPress when the card is pressed", async () => {
+    const handlePress = vi.fn();
+    render(<QueueCard name="Clickable" videoCount={5} onPress={handlePress} />);
+    screen.getByRole("button").click();
+    expect(handlePress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/QueueCard.tsx
+++ b/src/components/QueueCard.tsx
@@ -1,0 +1,29 @@
+import { Box, Pressable, Text, HStack, VStack } from "@/components/ui";
+
+interface QueueCardProps {
+  name: string;
+  videoCount: number;
+  isActive?: boolean;
+  onPress?: () => void;
+}
+
+export function QueueCard({ name, videoCount, isActive = false, onPress }: QueueCardProps) {
+  return (
+    <Pressable onPress={onPress}>
+      <Box
+        className={[
+          "rounded-xl px-4 py-3",
+          "bg-background-0 border border-outline-300",
+          isActive ? "border-l-4 border-l-primary-500" : "",
+        ].join(" ")}
+      >
+        <HStack space="sm" className="items-center">
+          <VStack className="flex-1">
+            <Text className="text-typography-900 font-bold text-md">{name}</Text>
+            <Text className="text-typography-400 text-sm">{videoCount} videos</Text>
+          </VStack>
+        </HStack>
+      </Box>
+    </Pressable>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      exclude: [
+        "node_modules/",
+        "src/test/",
+        "src/app/gluestack-ui-provider/",
+        "**/*.config.*",
+        "**/*.d.ts",
+      ],
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Source story

Closes #1 — Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

---

## Summary

(see issue body)

---

## Files changed

- `vitest.config.mts`
- `src/test/setup.ts`
- `.eslintrc.json`
- `.prettierrc`
- `commitlint.config.ts`
- `.husky/pre-commit`
- `.husky/commit-msg`
- `.husky/pre-push`
- `src/app/gluestack-ui-provider/config.ts`
- `src/app/layout.tsx`
- `src/components/QueueCard.tsx`
- `src/components/QueueCard.test.tsx`
- `README.md`
- `docs/code-context.md`

---

## Testing checklist

- [ ] `create-next-app` runs successfully with TypeScript, App Router, Tailwind, `src/` directory, and `@/*` path alias
- [ ] gluestack-ui v3 CLI init completes and the provider is correctly wired in the root layout
- [ ] QueueTube design tokens are applied in `gluestack-ui-provider/config.ts` (primary red, background scale, typography scale, radius)
- [ ] `pnpm dev` starts the dev server cleanly with no console errors
- [ ] Vitest is configured with `jsdom` environment, React plugin, and tsconfig path resolution
- [ ] `@testing-library/react` and `@testing-library/user-event` are installed and working
- [ ] A sample test for a synchronous component passes (`pnpm test:run`)
- [ ] `pnpm test:coverage` generates an HTML coverage report in `/coverage`
- [ ] Coverage thresholds (lines, branches, functions, statements ≥ 80%) are defined in `vitest.config.mts`
- [ ] `pnpm lint` runs ESLint with `next/core-web-vitals`, `tailwindcss/recommended`, and `prettier` extensions
- [ ] `pnpm format:check` runs with zero errors on a freshly bootstrapped project
- [ ] `eslint-plugin-tailwindcss` detects invalid Tailwind class names as lint errors
- [ ] `prettier-plugin-tailwindcss` reorders Tailwind classes automatically on format
- [ ] `pre-commit`: lint-staged runs ESLint + Prettier on staged `.ts/.tsx` files before commit — invalid commits are blocked
- [ ] `commit-msg`: commitlint rejects messages that don't follow Conventional Commits (e.g. `"fixed stuff"` fails; `"fix(queue): resolve null state"` passes)
- [ ] `pre-push`: full `tsc --noEmit` type check runs before push — type errors block the push
- [ ] `pre-push`: `vitest run --coverage` runs before push — coverage below 80% blocks the push
- [ ] All hooks can be bypassed with `--no-verify` for emergency use (documented in README)
- [ ] `README.md` documents all setup commands in order, including gluestack-ui init and token override step
- [ ] `README.md` includes a section on Git hooks: what each hook does, what it validates, and how to bypass in emergencies
- [ ] `docs/code-context.md` is created with the initial project baseline (directory tree, key config files, reference component) — used by the Code Sync agent
- [ ] Should `pre-push` also run `next build` to catch build-time errors? (Slower but more complete)
- [ ] Is pnpm the agreed package manager, or is npm/yarn preferred for this project?
- [ ] Should Playwright be set up in this issue as the E2E layer for async RSC testing, or tracked as a separate issue?
- [ ] Bootstrap Next.js project with all CLI flags
- [ ] Run `npx gluestack-ui init` and apply QueueTube token overrides
- [ ] Configure Vitest with coverage thresholds
- [ ] Configure ESLint + Prettier with Tailwind plugins
- [ ] Configure Husky with `pre-commit`, `commit-msg`, and `pre-push` hooks
- [ ] Configure lint-staged and commitlint
- [ ] Write a passing sample test to verify the test setup end-to-end
- [ ] Verify all three hooks fire correctly on a test commit and push
- [ ] Create `docs/code-context.md` with initial baseline content for the Code Sync agent
- [ ] Update `README.md` with full setup instructions and hook documentation

---

## Notes for reviewer

## Assumptions & Decisions

1. **Sample test as `QueueCard.test.tsx`**: The story requires a passing sample test to verify end-to-end test setup. `QueueCard` is the reference component in the baseline, making it the natural choice. Gluestack UI primitives are vi.mock'd with minimal HTML wrappers since the test environment doesn't support the full React Native rendering stack.

2. **`src/app/layout.tsx`**: A minimal root layout is provided that wires `GluestackUIProvider`. The import path `@/components/ui/gluestack-ui-provider` follows the pattern established by `npx gluestack-ui init`. If the actual generated path differs, the import line needs adjusting.

3. **`docs/code-context.md`**: Created with the same content as the baseline context already described in the story, as this is both the deliverable and the maintained agent context file.

4. **`README.md`**: Covers all ACs for documentation: setup commands in order, gluestack-ui init step, token override step, all scripts, and a full Git hooks section including what each hook validates and how to bypass with `--no-verify`.

5. **Husky hook files**: Written without `.sh` extension per Husky v9 convention. The shebang `#!/usr/bin/env sh` ensures POSIX compatibility.

6. **`package.json` not regenerated**: The full `package.json` is not output since it already exists in the baseline and modifying it would require merging with the full file. The story's `lint-staged` config and script additions should be applied manually or via a separate merge — this is noted as the primary AC not fully automated by code generation.

7. **`tailwind.config.ts` not generated**: This file is scaffolded by `create-next-app` + `gluestack-ui init` and requires the actual CSS variable mappings from the gluestack init output. It is not regenerated here to avoid overwriting the generated file incorrectly.

8. **Coverage provider**: The story mentions Istanbul in the tech stack table but the `vitest.config.mts` spec uses `v8` (which is what the official Next.js + Vitest template uses and matches `@vitest/coverage-v8`). v8 is used here as specified in the config section of the story.

---
*Generated by the QueueTube Code Agent · Powered by Claude*