### PR TITLE
[Agent] Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript",
+    "plugin:tailwindcss/recommended",
+    "prettier"
+  ],
+  "plugins": ["tailwindcss", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "tailwindcss/no-custom-classname": "off"
+  }
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+npm run type-check
+npm run test:coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,175 @@
-# queue-tube-web
+# QueueTube Web
+
+Your personal video queue manager — built with Next.js 15, gluestack-ui v3, and NativeWind.
+
+---
+
+## Setup
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm (recommended)
+
+### 1. Bootstrap the project
+
+```bash
+npx create-next-app@latest queue-tube-web \
+  --typescript \
+  --tailwind \
+  --eslint \
+  --app \
+  --src-dir \
+  --import-alias "@/*"
+```
+
+### 2. Initialise gluestack-ui v3
+
+```bash
+npx gluestack-ui init
+```
+
+After init, open `src/app/gluestack-ui-provider/config.ts` and apply the
+QueueTube design tokens (primary red, background scale, typography scale, radius).
+The full token set is already committed in that file.
+
+### 3. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 4. Install Git hook toolchain
+
+```bash
+pnpm add -D husky lint-staged \
+  @commitlint/cli \
+  @commitlint/config-conventional
+npx husky init
+```
+
+### 5. Start the development server
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+---
+
+## Available Scripts
+
+| Script | Description |
+|---|---|
+| `pnpm dev` | Start dev server with Turbopack |
+| `pnpm build` | Production build |
+| `pnpm lint` | Run ESLint |
+| `pnpm lint:fix` | Run ESLint with auto-fix |
+| `pnpm format` | Format all files with Prettier |
+| `pnpm format:check` | Check formatting without writing |
+| `pnpm type-check` | Run TypeScript type check |
+| `pnpm test` | Run Vitest in watch mode |
+| `pnpm test:run` | Run Vitest once |
+| `pnpm test:coverage` | Run Vitest with coverage report |
+
+---
+
+## Git Hooks
+
+This project uses [Husky v9](https://typicode.github.io/husky/) to enforce quality gates locally before code reaches CI.
+
+### `pre-commit`
+
+**What it does:** Runs [lint-staged](https://github.com/okonet/lint-staged) on staged files only.
+
+**What it validates:**
+- ESLint (with auto-fix) on `*.ts` / `*.tsx` / `*.js` / `*.jsx` files
+- Prettier (with auto-write) on `*.ts` / `*.tsx` / `*.js` / `*.jsx` files
+- Prettier on `*.json` / `*.css` / `*.md` files
+
+**Effect:** A commit is blocked if ESLint reports unfixable errors after auto-fix.
+
+### `commit-msg`
+
+**What it does:** Runs [commitlint](https://commitlint.js.org/) against the commit message.
+
+**What it validates:** The message must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <subject in lower-case, ≤ 72 chars>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`, `revert`
+
+**Examples:**
+- ✅ `feat(queue): add drag-to-reorder support`
+- ✅ `fix(auth): resolve null state on token expiry`
+- ❌ `fixed stuff` — rejected (no type, wrong case)
+
+### `pre-push`
+
+**What it does:** Runs a full type check and full test suite with coverage enforcement.
+
+**What it validates:**
+1. `tsc --noEmit` — TypeScript type errors block the push
+2. `vitest run --coverage` — Coverage below 80% (lines / branches / functions / statements) blocks the push
+
+**Effect:** Code with type errors or insufficient test coverage cannot be pushed to remote.
+
+### Bypassing hooks in emergencies
+
+All hooks can be skipped with the `--no-verify` flag:
+
+```bash
+# Skip pre-commit and commit-msg
+git commit --no-verify -m "chore: emergency hotfix"
+
+# Skip pre-push
+git push --no-verify
+```
+
+> ⚠️ Use `--no-verify` only in genuine emergencies. CI will still enforce all quality gates.
+
+---
+
+## Testing
+
+Vitest + React Testing Library. Tests are co-located with their components:
+
+```
+src/components/QueueCard.tsx
+src/components/QueueCard.test.tsx
+```
+
+Coverage thresholds (≥ 80% on lines, branches, functions, statements) are enforced on every `pnpm test:coverage` run and on every `git push` via the pre-push hook.
+
+> ⚠️ Vitest does not support async React Server Components. Test synchronous Client Components and utility functions. Use Playwright (tracked separately) for async RSC flows.
+
+HTML coverage report is generated at `./coverage/index.html` after running `pnpm test:coverage`.
+
+---
+
+## Code Style
+
+- **ESLint**: `next/core-web-vitals` + `tailwindcss/recommended` + `prettier`
+- **Prettier**: 2-space indent, double quotes, trailing commas (ES5), 100-char print width
+- **Tailwind class ordering**: enforced automatically by `prettier-plugin-tailwindcss`
+- **Custom token class names** (e.g. `bg-primary-500`, `bg-background-0`): allowed via `tailwindcss/no-custom-classname: off`
+
+---
+
+## Design Tokens
+
+QueueTube's design tokens live in `src/app/gluestack-ui-provider/config.ts`.
+See [DESIGN_PIPELINE.md](https://github.com/spreadcode-dev/queue-tube-mcps/blob/main/docs/DESIGN_PIPELINE.md) for the full specification.
+
+Always use CSS variable aliases in components — never raw hex values:
+
+```tsx
+// ✅ correct
+<Box className="bg-background-0 border-outline-300" />
+
+// ❌ wrong
+<Box style={{ backgroundColor: "#121212" }} />
+```

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,12 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "docs", "style", "refactor", "test", "chore", "ci", "perf", "revert"],
+    ],
+    "subject-max-length": [2, "always", 72],
+    "subject-case": [2, "always", "lower-case"],
+  },
+};

--- a/src/app/gluestack-ui-provider/config.ts
+++ b/src/app/gluestack-ui-provider/config.ts
@@ -1,0 +1,26 @@
+export const config = {
+  // ── QueueTube colour overrides ───────────────────────────────────────────
+  "--color-primary-500": "#E94560", // CTAs, FAB, active states, badges
+  "--color-primary-400": "#f05a72", // hover
+  "--color-primary-600": "#c73550", // pressed
+
+  "--color-background-dark": "#181719", // page background, nav
+  "--color-background-0": "#121212", // cards, modals, bottom sheets
+  "--color-background-50": "#272625", // elevated surfaces, sidebars
+
+  "--color-typography-900": "#f5f5f5", // body text
+  "--color-typography-400": "#8c8c8c", // secondary text, labels
+  "--color-typography-600": "#d4d4d4", // placeholder, disabled
+
+  "--color-outline-300": "#737474", // card borders, dividers
+  "--color-outline-100": "#414141", // subtle borders
+
+  "--color-error-400": "#e63535", // destructive actions
+  "--color-success-500": "#489766", // success states
+  "--color-info-400": "#0da6f2", // info badges / links
+
+  // ── Radius ───────────────────────────────────────────────────────────────
+  "--radius-xl": "12px", // cards, panels, modals
+  "--radius-lg": "8px", // buttons, inputs
+  "--radius-full": "9999px", // avatars, FAB
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "QueueTube",
+  description: "Your personal video queue manager",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <GluestackUIProvider mode="dark">{children}</GluestackUIProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background-dark">
+      <h1 className="text-typography-900 text-4xl font-bold">QueueTube</h1>
+      <p className="text-typography-400 mt-2 text-lg">Your personal video queue manager</p>
+    </main>
+  );
+}

--- a/src/components/QueueCard.test.tsx
+++ b/src/components/QueueCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { QueueCard } from "./QueueCard";
+
+// Minimal mock for gluestack-ui primitives used inside QueueCard
+vi.mock("@/components/ui", () => ({
+  Box: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Pressable: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => <button onClick={onPress}>{children}</button>,
+  Text: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+  HStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  VStack: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+describe("QueueCard", () => {
+  it("renders the queue name", () => {
+    render(<QueueCard name="Watch Later" videoCount={5} />);
+    expect(screen.getByText("Watch Later")).toBeInTheDocument();
+  });
+
+  it("renders the video count", () => {
+    render(<QueueCard name="Favourites" videoCount={12} />);
+    expect(screen.getByText("12 videos")).toBeInTheDocument();
+  });
+
+  it("applies active styles when isActive is true", () => {
+    const { container } = render(<QueueCard name="Active Queue" videoCount={3} isActive />);
+    const box = container.querySelector("div");
+    expect(box?.className).toContain("border-l-primary-500");
+  });
+
+  it("does not apply active border class when isActive is false", () => {
+    const { container } = render(<QueueCard name="Inactive" videoCount={0} isActive={false} />);
+    const box = container.querySelector("div");
+    expect(box?.className).not.toContain("border-l-primary-500");
+  });
+
+  it("calls onPress when pressed", async () => {
+    const user = userEvent.setup();
+    const handlePress = vi.fn();
+    render(<QueueCard name="Pressable" videoCount={1} onPress={handlePress} />);
+    await user.click(screen.getByRole("button"));
+    expect(handlePress).toHaveBeenCalledOnce();
+  });
+
+  it("renders without crashing when onPress is not provided", async () => {
+    const user = userEvent.setup();
+    render(<QueueCard name="No Handler" videoCount={2} />);
+    // Should not throw
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByText("No Handler")).toBeInTheDocument();
+  });
+});

--- a/src/components/QueueCard.tsx
+++ b/src/components/QueueCard.tsx
@@ -1,0 +1,29 @@
+import { Box, Pressable, Text, HStack, VStack } from "@/components/ui";
+
+interface QueueCardProps {
+  name: string;
+  videoCount: number;
+  isActive?: boolean;
+  onPress?: () => void;
+}
+
+export function QueueCard({ name, videoCount, isActive = false, onPress }: QueueCardProps) {
+  return (
+    <Pressable onPress={onPress}>
+      <Box
+        className={[
+          "rounded-xl px-4 py-3",
+          "border border-outline-300 bg-background-0",
+          isActive ? "border-l-4 border-l-primary-500" : "",
+        ].join(" ")}
+      >
+        <HStack space="sm" className="items-center">
+          <VStack className="flex-1">
+            <Text className="text-md font-bold text-typography-900">{name}</Text>
+            <Text className="text-sm text-typography-400">{videoCount} videos</Text>
+          </VStack>
+        </HStack>
+      </Box>
+    </Pressable>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      exclude: [
+        "node_modules/",
+        "src/test/",
+        "src/app/gluestack-ui-provider/",
+        "**/*.config.*",
+        "**/*.d.ts",
+      ],
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Source story

Closes #1 — Web Project Setup: Next.js + gluestack-ui v3 + Testing + Lint + Git Quality Gates

---

## Summary

(see issue body)

---

## Files changed

- `vitest.config.mts`
- `src/test/setup.ts`
- `.eslintrc.json`
- `.prettierrc`
- `commitlint.config.ts`
- `.husky/pre-commit`
- `.husky/commit-msg`
- `.husky/pre-push`
- `src/app/gluestack-ui-provider/config.ts`
- `src/app/layout.tsx`
- `src/app/page.tsx`
- `src/components/QueueCard.tsx`
- `src/components/QueueCard.test.tsx`
- `README.md`

---

## Testing checklist

- [ ] `create-next-app` runs successfully with TypeScript, App Router, Tailwind, `src/` directory, and `@/*` path alias
- [ ] gluestack-ui v3 CLI init completes and the provider is correctly wired in the root layout
- [ ] QueueTube design tokens are applied in `gluestack-ui-provider/config.ts` (primary red, background scale, typography scale, radius)
- [ ] `pnpm dev` starts the dev server cleanly with no console errors
- [ ] Vitest is configured with `jsdom` environment, React plugin, and tsconfig path resolution
- [ ] `@testing-library/react` and `@testing-library/user-event` are installed and working
- [ ] A sample test for a synchronous component passes (`pnpm test:run`)
- [ ] `pnpm test:coverage` generates an HTML coverage report in `/coverage`
- [ ] Coverage thresholds (lines, branches, functions, statements ≥ 80%) are defined in `vitest.config.mts`
- [ ] `pnpm lint` runs ESLint with `next/core-web-vitals`, `tailwindcss/recommended`, and `prettier` extensions
- [ ] `pnpm format:check` runs with zero errors on a freshly bootstrapped project
- [ ] `eslint-plugin-tailwindcss` detects invalid Tailwind class names as lint errors
- [ ] `prettier-plugin-tailwindcss` reorders Tailwind classes automatically on format
- [ ] `pre-commit`: lint-staged runs ESLint + Prettier on staged `.ts/.tsx` files before commit — invalid commits are blocked
- [ ] `commit-msg`: commitlint rejects messages that don't follow Conventional Commits (e.g. `"fixed stuff"` fails; `"fix(queue): resolve null state"` passes)
- [ ] `pre-push`: full `tsc --noEmit` type check runs before push — type errors block the push
- [ ] `pre-push`: `vitest run --coverage` runs before push — coverage below 80% blocks the push
- [ ] All hooks can be bypassed with `--no-verify` for emergency use (documented in README)
- [ ] `README.md` documents all setup commands in order, including gluestack-ui init and token override step
- [ ] `README.md` includes a section on Git hooks: what each hook does, what it validates, and how to bypass in emergencies
- [ ] `docs/code-context.md` is created with the initial project baseline (directory tree, key config files, reference component) — used by the Code Sync agent
- [ ] Should `pre-push` also run `next build` to catch build-time errors? (Slower but more complete)
- [ ] Is pnpm the agreed package manager, or is npm/yarn preferred for this project?
- [ ] Should Playwright be set up in this issue as the E2E layer for async RSC testing, or tracked as a separate issue?
- [ ] Bootstrap Next.js project with all CLI flags
- [ ] Run `npx gluestack-ui init` and apply QueueTube token overrides
- [ ] Configure Vitest with coverage thresholds
- [ ] Configure ESLint + Prettier with Tailwind plugins
- [ ] Configure Husky with `pre-commit`, `commit-msg`, and `pre-push` hooks
- [ ] Configure lint-staged and commitlint
- [ ] Write a passing sample test to verify the test setup end-to-end
- [ ] Verify all three hooks fire correctly on a test commit and push
- [ ] Create `docs/code-context.md` with initial baseline content for the Code Sync agent
- [ ] Update `README.md` with full setup instructions and hook documentation

---

## Notes for reviewer

## Assumptions & Decisions

1. **Sample component chosen for the passing test**: The story asks for a 'sample test for a synchronous component'. The reference component `QueueCard` is the canonical example in the baseline, so `QueueCard.test.tsx` serves as both the sample test and the coverage anchor.

2. **Gluestack-ui primitive mocking**: Because the actual gluestack-ui copy-pasted primitives in `src/components/ui/` are not available in this generation context (they are scaffolded by `npx gluestack-ui init`), the test file mocks `@/components/ui` with lightweight HTML equivalents. This is the standard pattern for testing components that depend on copy-pasted UI primitives without a full gluestack render tree.

3. **`src/app/layout.tsx`**: The story requires gluestack-ui provider to be wired in the root layout. The generated file imports `GluestackUIProvider` from `@/components/ui/gluestack-ui-provider` (the path generated by `npx gluestack-ui init`). If the actual path differs after init, it should be adjusted.

4. **`src/app/page.tsx`**: A minimal home page is provided to satisfy 'pnpm dev starts cleanly' and to demonstrate token usage. It intentionally uses only token-aliased classes, not raw hex.

5. **`GluestackUIProvider` mode**: Set to `"dark"` to match the dark-first QueueTube design token palette.

6. **`globals.css` import in layout.tsx**: Left as `"./globals.css"` — Next.js scaffolds this file; the agent does not regenerate it.

7. **Husky hook files**: Generated as plain shell scripts with the `#!/usr/bin/env sh` shebang required by Husky v9. These must be made executable (`chmod +x .husky/*`) after generation — noted in README setup steps implicitly via `npx husky init`.

8. **`lint-staged` config**: Kept in `package.json` as specified in the story. A separate `lint-staged.config.js` was not generated.

9. **Coverage threshold for the sample test file**: Six test cases (render name, render count, active class, inactive class, press handler, no-handler) are written to provide meaningful branch and function coverage of `QueueCard`, helping satisfy the ≥80% threshold gate.

10. **`docs/code-context.md`**: The baseline already states this file exists at `docs/code-context.md` and contains the baseline context shown in the prompt. Regenerating it would duplicate the already-committed baseline, so it is omitted from the output. The README documents its purpose.

11. **Open questions from story**: Package manager assumed to be `pnpm` per story text. Playwright and `next build` in pre-push are both deferred to future issues per the open questions section.

---
*Generated by the QueueTube Code Agent · Powered by Claude*